### PR TITLE
docs: Shorten and simplify README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,232 +4,51 @@
 
 ---
 
-Eine moderne Progressive Web App zur Verwaltung deines Musikrepertoires - vollständig offline nutzbar!
+Progressive Web App für dein Musikrepertoire - installierbar und vollständig offline nutzbar!
 
 > **SpelBok** (Schwedisch) = Liederbuch/Spielbuch für Musiker
 
-## ✨ Features
+## ✨ Hauptfunktionen
 
-### 📱 **Progressive Web App (PWA)**
-- ✅ **Installierbar** auf iPhone, iPad, Android und Desktop
-- ✅ **Offline-Funktionalität** - nutze die App ohne Internet
-- ✅ **Native App Erfahrung** - läuft im Vollbild ohne Browser
-- ✅ **Automatische Updates** - immer die neueste Version
-- ✅ **Kleiner Speicherbedarf** - nur ~50 KB statt mehrere MB
-- ✅ **Home-Bildschirm Icon** - schneller Zugriff wie eine echte App
+- 📱 **PWA** - Installierbar auf allen Geräten, funktioniert offline
+- 🌐 **3 Sprachen** - Schwedisch, Deutsch, Englisch
+- 🔍 **Suche & Filter** - Nach Region, Schwierigkeit, Typ
+- 📥 **Import/Export** - JSON-Backup mit Duplikatserkennung
+- 🔗 **Klickbare Links** - URLs und Dateipfade automatisch verlinkt
+- 💾 **IndexedDB** - Sichere lokale Datenspeicherung
 
-### 🌐 **Mehrsprachigkeit**
-- **Schwedisch (Svenska)** - Standardsprache
-- **Deutsch** - Vollständige deutsche Übersetzung
-- **Englisch (English)** - Vollständige englische Übersetzung
-- Sprachauswahl oben rechts im Header
-- Sprachwahl wird automatisch gespeichert
+## 🚀 Installation
 
-### 📊 **Datenverwaltung**
-- ✅ Hinzufügen, Bearbeiten & Löschen von Liedern
-- ✅ 15 Datenfelder für umfassende Dokumentation
-- ✅ Automatische Speicherung in localStorage
-- ✅ Daten bleiben dauerhaft im Browser erhalten
-- ✅ Zuverlässiges ID-System verhindert versehentliches Löschen mehrerer Einträge
+### iPhone/iPad (Safari):
+1. Öffne die App in Safari
+2. Tippe auf Teilen-Symbol (□↑)
+3. Wähle "Zum Home-Bildschirm"
 
-### 🔍 **Such- und Filterfunktionen**
-- Volltext-Suche über alle Felder
-- Filter nach Region (Landskap)
-- Filter nach Schwierigkeitsgrad
-- Filter nach Typ (Traditionell/Neu/Modern)
-
-### 📥 **Import & Export**
-- Exportiere dein Repertoire als JSON-Datei
-- Importiere JSON-Dateien (Backup-Funktion)
-- **Automatische Duplikatserkennung**: Beim Import werden Songs, die bereits vorhanden sind (alle Felder identisch), automatisch übersprungen
-- Sichere deine Daten regelmäßig!
-
-### 📱 **Responsive Design**
-- Funktioniert auf Desktop, Tablet und Smartphone
-- Modernes Design mit Gradient-Hintergrund
-- Übersichtliche Tabellenansicht
-
-## 🚀 Installation & Verwendung
-
-### 🌟 Als PWA installieren (EMPFOHLEN für iOS/iPad)
-
-Die App kann als Progressive Web App installiert werden und läuft dann wie eine native App!
-
-#### iPhone/iPad (Safari):
-1. **Öffne die App-URL** in Safari (z.B. https://StarOnDavid.github.io/spelbok/)
-2. Tippe auf das **Teilen-Symbol** (□↑)
-3. Wähle **"Zum Home-Bildschirm"**
-4. Tippe auf **"Hinzufügen"**
-5. **Fertig!** Die App ist jetzt auf deinem Home-Bildschirm als "SpelBok"
-
-#### Android (Chrome):
-1. **Chrome öffnen** und App öffnen
-2. Tippe auf **"App installieren"** im Banner
-3. Oder: Menü (⋮) → **"App installieren"**
-4. **Fertig!** App läuft wie native App
-
-#### Desktop (Chrome/Edge):
+### Android/Desktop:
 1. Öffne die App im Browser
-2. Klicke auf das **⊕ Icon** in der Adressleiste
-3. Klicke auf **"Installieren"**
-
-**✨ Vorteile der PWA-Installation:**
-- 📱 Läuft im Vollbild (kein Browser)
-- 🚀 Funktioniert offline
-- ⚡ Schneller Start
-- 🏠 Eigenes Icon auf Home-Bildschirm
-- 🔄 Automatische Updates
-
----
-
-### 📱 PWA vs. normale Nutzung
-
-| Feature | PWA (installiert) | Normal (Browser) |
-|---------|-------------------|------------------|
-| **Offline** | ✅ Ja | ❌ Nein |
-| **Home-Icon** | ✅ Ja | ❌ Nein |
-| **Vollbild** | ✅ Ja | ❌ Nein |
-| **Schneller Start** | ✅ Ja | 🟡 Langsamer |
-| **Updates** | ✅ Automatisch | 🟡 Manuell |
-
-**Empfehlung:** Für die beste Erfahrung auf Mobilgeräten die PWA-Installation nutzen!
-
-### Systemanforderungen
-- Moderner Webbrowser (Chrome, Firefox, Safari, Edge)
-- JavaScript muss aktiviert sein
-- Keine Internetverbindung erforderlich
+2. Klicke auf "App installieren"
 
 ## 📋 Datenfelder
 
-Die App erfasst folgende Informationen zu jedem Lied:
-
-1. **Titel** - Name/Bezeichnung des Liedes (z.B. Bingsjöpolska efter Hjort Anders)
-2. **Låttyp** - Art des Liedes (z.B. Polska, Vals, Slängpolska)
-3. **Efter/Av** - Komponist oder Quelle
-4. **Ort** - Stadt oder Dorf
-5. **Landskap** - Region (z.B. Dalarna, Skåne)
-6. **Land** - Land (z.B. Schweden, Norwegen)
-7. **Tonart** - Tonart des Liedes
-8. **Svårighetsgrad** - Schwierigkeitsgrad (Leicht/Mittel/Schwer/Sehr schwer)
-9. **Utmaningar** - Herausforderungen und Übungsschwerpunkte
-10. **Av vem lärde jag mig låten?** - Von wem du das Lied gelernt hast
-11. **Var hittar jag inspelning?** - Wo die Aufnahme zu finden ist
-12. **Not?** - Verfügbarkeit von Noten
-13. **Instrument kommentar** - Kommentare zum Instrument
-14. **Trad eller ny** - Traditionell, Neu oder Moderne Interpretation
-15. **Andra kommentarer** - Weitere Notizen
+Erfasse umfassende Informationen zu jedem Lied:
+- Titel, Låttyp, Komponist, Ort, Region, Land
+- Tonart, Schwierigkeitsgrad, Herausforderungen
+- Quelle, Aufnahmen, Noten, Instrument
+- Typ (Traditionell/Neu/Modern), Kommentare
 
 ## 💾 Datensicherheit
 
-### Wo werden die Daten gespeichert?
-Die Daten werden im **localStorage** deines Browsers gespeichert:
-- ✅ Automatische Speicherung bei jeder Änderung
-- ✅ Daten bleiben nach Browser-Neustart erhalten
-- ✅ Keine Cloud, keine externe Datenbank
+- Daten werden lokal im Browser gespeichert
+- Regelmäßig Backups mit Export-Funktion erstellen
+- Import erkennt Duplikate automatisch
 
-### ⚠️ Wichtige Hinweise
-- **Lösche nicht den Browser-Cache** - sonst gehen deine Daten verloren!
-- **Erstelle regelmäßig Backups** mit der Export-Funktion
-- **Privates Browsen** speichert keine Daten dauerhaft
+## 🛠️ Technik
 
-### Backup erstellen
-1. Klicke auf "📥 Exportera JSON" / "JSON exportieren" / "Export JSON"
-2. Speichere die JSON-Datei an einem sicheren Ort
-3. Bei Bedarf: Importiere die Datei mit "📤 Importera JSON"
+- Vanilla JavaScript, HTML5, CSS3
+- IndexedDB mit Dexie.js
+- Service Worker für Offline-Funktionalität
+- i18n für Mehrsprachigkeit
 
-### Import mit Duplikatserkennung
-Beim Import von JSON-Dateien prüft die App automatisch auf Duplikate:
-- **Duplikatsprüfung**: Songs werden als Duplikat erkannt, wenn ALLE Felder (außer ID) identisch sind
-- **Automatisches Überspringen**: Duplikate werden nicht importiert
-- **Statusmeldung**: Du erhältst eine Meldung, wie viele Songs importiert und wie viele übersprungen wurden
-- **Beispiel**: Wenn du 20 Songs importierst und 5 bereits vorhanden sind, werden nur 15 neue hinzugefügt
+## 📄 Lizenz
 
-Dies schützt vor versehentlichem doppelten Import derselben Daten!
-
-## 🌐 Sprache wechseln
-
-1. Klicke oben rechts auf das **Globus-Icon** 🌐
-2. Wähle deine gewünschte Sprache:
-   - **Svenska** (Schwedisch)
-   - **Deutsch** (Deutsch)
-   - **English** (Englisch)
-3. Die gesamte Benutzeroberfläche wird sofort übersetzt
-4. Deine Sprachwahl wird automatisch gespeichert
-
-## 🎯 Verwendungstipps
-
-### Effizienter Arbeiten
-- Verwende die **Suche** für schnellen Zugriff auf bestimmte Lieder
-- Nutze **Filter** um dein Repertoire nach Kategorien zu sortieren
-- Die **Statistik** zeigt dir auf einen Blick die Zusammensetzung deines Repertoires
-
-### Best Practices
-- Fülle so viele Felder wie möglich aus - je mehr Information, desto besser
-- Nutze das "Utmaningar"-Feld für Übungsnotizen
-- Verlinke Aufnahmen direkt (YouTube, Spotify, etc.)
-- Erstelle wöchentlich ein Backup deiner Daten
-
-## 🛠️ Technische Details
-
-### Moderne Architektur (v2.0.0)
-Die App nutzt eine **modulare Struktur** mit getrennten Dateien:
-
-**Struktur:**
-```
-spelbok/
-├── index.html           # Haupt-HTML (Entry Point)
-├── manifest.json        # PWA Konfiguration
-├── sw.js               # Service Worker (Cache v2.0.0)
-├── assets/
-│   ├── css/styles.css  # Stylesheet (7.4 KB)
-│   └── js/app.js       # App-Logik (14 KB)
-└── docs/               # Dokumentation
-```
-
-**Service Worker (spelbok-v2.0.0):**
-- Ermöglicht Offline-Funktionalität
-- Cached HTML, CSS, JS und manifest.json
-- Automatische Updates im Hintergrund
-
-**Web App Manifest:**
-- Name: "SpelBok - Din digitala spelbok"
-- Definiert App-Eigenschaften (Icons, Farben, Start-URL)
-- Ermöglicht Installation auf Home-Bildschirm
-- iOS- und Android-optimiert
-
-**LocalStorage API:**
-- Persistente Datenspeicherung im Browser
-- Keine Server-Verbindung erforderlich
-- Daten bleiben auch offline verfügbar
-
-### ID-System
-Jeder Song erhält beim Erstellen eine eindeutige ID im Format `song_timestamp_randomstring`. Diese ID:
-- Wird automatisch generiert
-- Ist nicht sichtbar für den Benutzer
-- Gewährleistet sichere Lösch- und Bearbeitungsoperationen
-- Verhindert Konflikte beim Import/Export
-- Bei bestehenden Daten werden alte IDs automatisch migriert
-
-### Technologie-Stack
-- **HTML5, CSS3, ES6 JavaScript** - keine Frameworks, pure vanilla JS
-- **localStorage API** - für Datenspeicherung
-- **Responsive Design** - funktioniert auf allen Geräten
-- **Progressive Web App** - mit Service Worker und Manifest
-- **Mehrsprachigkeit** - Schwedisch, Deutsch, Englisch
-
-### Browser-Kompatibilität
-- ✅ Chrome/Chromium (ab Version 60)
-- ✅ Firefox (ab Version 50)
-- ✅ Safari (ab Version 11)
-- ✅ Edge (ab Version 79)
-- ✅ Opera (ab Version 47)
-
-## 📄 Lizenz & Copyright
-
-**© 2025 David Staron**
-
-Diese App ist frei verwendbar für private und kommerzielle Zwecke.
-
----
-
-## 🎵 Viel Spaß mit SpelBok!
+© 2025 David Staron - Frei verwendbar

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -1,235 +1,54 @@
-# 🎵 SpelBok - Your digital songbook
+# 🎵 SpelBok - Your Digital Songbook
 
-**[🇸🇪 Svenska](README.sv.md)** | **[🇩🇪 Deutsch](../README.md)**
+**[🇩🇪 Deutsch](../README.md)** | **[🇸🇪 Svenska](README.sv.md)**
 
 ---
 
-A modern Progressive Web App for managing your music repertoire - fully functional offline!
+Progressive Web App for your music repertoire - installable and fully functional offline!
 
 > **SpelBok** (Swedish) = Songbook/Playbook for musicians
 
-## ✨ Features
+## ✨ Main Features
 
-### 📱 **Progressive Web App (PWA)**
-- ✅ **Installable** on iPhone, iPad, Android and Desktop
-- ✅ **Offline functionality** - use the app without internet
-- ✅ **Native app experience** - runs fullscreen without browser
-- ✅ **Automatic updates** - always the latest version
-- ✅ **Small storage requirement** - only ~50 KB instead of several MB
-- ✅ **Home screen icon** - quick access like a real app
+- 📱 **PWA** - Installable on all devices, works offline
+- 🌐 **3 Languages** - Swedish, German, English
+- 🔍 **Search & Filter** - By region, difficulty, type
+- 📥 **Import/Export** - JSON backup with duplicate detection
+- 🔗 **Clickable Links** - URLs and file paths automatically linked
+- 💾 **IndexedDB** - Secure local data storage
 
-### 🌐 **Multilingual**
-- **Svenska (Swedish)** - Default language
-- **Deutsch (German)** - Complete German translation
-- **English** - Complete English translation
-- Language selection in the top right corner
-- Language choice is saved automatically
+## 🚀 Installation
 
-### 📊 **Data Management**
-- ✅ Add, edit & delete songs
-- ✅ 15 data fields for comprehensive documentation
-- ✅ Automatic saving in localStorage
-- ✅ Data persists in the browser
-- ✅ Reliable ID system prevents accidental deletion of multiple entries
+### iPhone/iPad (Safari):
+1. Open the app in Safari
+2. Tap the Share icon (□↑)
+3. Select "Add to Home Screen"
 
-### 🔍 **Search and Filter Functions**
-- Full-text search across all fields
-- Filter by region (Landskap)
-- Filter by difficulty level
-- Filter by type (Traditional/New/Modern)
-
-### 📥 **Import & Export**
-- Export your repertoire as JSON file
-- Import JSON files (backup function)
-- **Automatic duplicate detection**: During import, songs that already exist (all fields identical) are automatically skipped
-- Back up your data regularly!
-
-### 📱 **Responsive Design**
-- Works on Desktop, Tablet and Smartphone
-- Modern design with gradient background
-- Clear table view
-
-## 🚀 Installation & Usage
-
-### 🌟 Install as PWA (RECOMMENDED for iOS/iPad)
-
-The app can be installed as a Progressive Web App and then runs like a native app!
-
-#### iPhone/iPad (Safari):
-1. **Open the app URL** in Safari (e.g. https://StarOnDavid.github.io/spelbok/)
-2. Tap the **Share icon** (□↑)
-3. Select **"Add to Home Screen"**
-4. Tap **"Add"**
-5. **Done!** The app is now on your home screen as "SpelBok"
-
-#### Android (Chrome):
-1. **Open Chrome** and open the app
-2. Tap **"Install app"** in the banner
-3. Or: Menu (⋮) → **"Install app"**
-4. **Done!** App runs like a native app
-
-#### Desktop (Chrome/Edge):
-1. Open the app in the browser
-2. Click on the **⊕ icon** in the address bar
-3. Click **"Install"**
-
-**✨ Advantages of PWA installation:**
-- 📱 Runs fullscreen (no browser)
-- 🚀 Works offline
-- ⚡ Faster startup
-- 🏠 Own icon on home screen
-- 🔄 Automatic updates
-
----
-
-### 📱 PWA vs. normal usage
-
-| Feature | PWA (installed) | Normal (browser) |
-|---------|-----------------|------------------|
-| **Offline** | ✅ Yes | ❌ No |
-| **Home Icon** | ✅ Yes | ❌ No |
-| **Fullscreen** | ✅ Yes | ❌ No |
-| **Faster Start** | ✅ Yes | 🟡 Slower |
-| **Updates** | ✅ Automatic | 🟡 Manual |
-
-**Recommendation:** For the best experience on mobile devices, use PWA installation!
-
-### System Requirements
-- Modern web browser (Chrome, Firefox, Safari, Edge)
-- JavaScript must be enabled
-- No internet connection required
+### Android/Desktop:
+1. Open the app in browser
+2. Click "Install app"
 
 ## 📋 Data Fields
 
-The app captures the following information for each song:
-
-1. **Title** - Song name (e.g. Bingsjöpolska efter Hjort Anders)
-2. **Låttyp** - Type of song (e.g. Polska, Vals, Slängpolska)
-3. **Efter/Av** - Composer or source
-4. **Place** - City or village
-5. **Landskap** - Region (e.g. Dalarna, Skåne)
-6. **Country** - Country (e.g. Sweden, Norway)
-7. **Key** - Musical key
-8. **Difficulty** - Difficulty level (Easy/Medium/Hard/Very hard)
-9. **Challenges** - Challenges and practice focus
-10. **Who did I learn the song from?** - Your teacher or source
-11. **Where can I find a recording?** - Location of recording
-12. **Sheet music?** - Availability of sheet music
-13. **Instrument comment** - Comments about instrument
-14. **Traditional or new** - Traditional, New or Modern interpretation
-15. **Other comments** - Additional notes
+Record comprehensive information about each song:
+- Title, Song Type, Composer, Location, Region, Country
+- Key, Difficulty, Challenges
+- Source, Recordings, Sheet Music, Instrument
+- Type (Traditional/New/Modern), Comments
 
 ## 💾 Data Security
 
-### Where is the data stored?
-Data is stored in your browser's **localStorage**:
-- ✅ Automatic saving with every change
-- ✅ Data persists after browser restart
-- ✅ No cloud, no external database
+- Data is stored locally in the browser
+- Create regular backups using the export function
+- Import automatically detects duplicates
 
-### ⚠️ Important Notes
-- **Don't clear browser cache** - or your data will be lost!
-- **Create regular backups** using the export function
-- **Private browsing** doesn't save data permanently
+## 🛠️ Technology
 
-### Create Backup
-1. Click "📥 Export JSON"
-2. Save the JSON file in a safe location
-3. If needed: Import the file with "📤 Import JSON"
+- Vanilla JavaScript, HTML5, CSS3
+- IndexedDB with Dexie.js
+- Service Worker for offline functionality
+- i18n for multilingual support
 
-### Import with Duplicate Detection
-When importing JSON files, the app automatically checks for duplicates:
-- **Duplicate check**: Songs are identified as duplicates if ALL fields (except ID) are identical
-- **Automatic skip**: Duplicates are not imported
-- **Status message**: You'll receive a message about how many songs were imported and how many were skipped
-- **Example**: If you import 20 songs and 5 already exist, only 15 new ones will be added
+## 📄 License
 
-This protects against accidental duplicate import of the same data!
-
-## 🌐 Change Language
-
-1. Click the **Globe icon** 🌐 in the top right
-2. Select your desired language:
-   - **Svenska** (Swedish)
-   - **Deutsch** (German)
-   - **English** (English)
-3. The entire user interface is translated immediately
-4. Your language choice is saved automatically
-
-## 🎯 Usage Tips
-
-### Work Efficiently
-- Use **search** for quick access to specific songs
-- Use **filters** to sort your repertoire by categories
-- The **statistics** show you the composition of your repertoire at a glance
-
-### Best Practices
-- Fill in as many fields as possible - the more information, the better
-- Use the "Challenges" field for practice notes
-- Link recordings directly (YouTube, Spotify, etc.)
-- Create a backup of your data weekly
-
-## 🛠️ Technical Details
-
-### Modern Architecture (v2.0.0)
-The app uses a **modular structure** with separate files:
-
-**Structure:**
-```
-spelbok/
-├── index.html           # Main HTML (Entry Point)
-├── manifest.json        # PWA Configuration
-├── sw.js               # Service Worker (Cache v2.0.0)
-├── assets/
-│   ├── css/styles.css  # Stylesheet (7.4 KB)
-│   └── js/app.js       # App Logic (14 KB)
-└── docs/               # Documentation
-```
-
-**Service Worker (spelbok-v2.0.0):**
-- Enables offline functionality
-- Caches HTML, CSS, JS and manifest.json
-- Automatic updates in the background
-
-**Web App Manifest:**
-- Name: "SpelBok - Din digitala spelbok"
-- Defines app properties (icons, colors, start URL)
-- Enables installation on home screen
-- iOS and Android optimized
-
-**LocalStorage API:**
-- Persistent data storage in browser
-- No server connection required
-- Data remains available offline
-
-### ID System
-Each song receives a unique ID when created in the format `song_timestamp_randomstring`. This ID:
-- Is generated automatically
-- Is not visible to the user
-- Ensures safe deletion and editing operations
-- Prevents conflicts during import/export
-- For existing data, old IDs are automatically migrated
-
-### Technology Stack
-- **HTML5, CSS3, ES6 JavaScript** - no frameworks, pure vanilla JS
-- **localStorage API** - for data storage
-- **Responsive design** - works on all devices
-- **Progressive Web App** - with Service Worker and Manifest
-- **Multilingual** - Swedish, German, English
-
-### Browser Compatibility
-- ✅ Chrome/Chromium (from version 60)
-- ✅ Firefox (from version 50)
-- ✅ Safari (from version 11)
-- ✅ Edge (from version 79)
-- ✅ Opera (from version 47)
-
-## 📄 License & Copyright
-
-**© 2025 David Staron**
-
-This app is freely usable for private and commercial purposes.
-
----
-
-## 🎵 Enjoy SpelBok!
+© 2025 David Staron - Free to use

--- a/docs/README.sv.md
+++ b/docs/README.sv.md
@@ -4,232 +4,51 @@
 
 ---
 
-En modern Progressive Web App för att hantera ditt musikrepertoar - fullt fungerande offline!
+Progressive Web App för ditt musikrepertoar - installerbar och fullt fungerande offline!
 
 > **SpelBok** = Liederbuch/Spielbuch för musiker
 
-## ✨ Funktioner
+## ✨ Huvudfunktioner
 
-### 📱 **Progressive Web App (PWA)**
-- ✅ **Installerbar** på iPhone, iPad, Android och Desktop
-- ✅ **Offline-funktionalitet** - använd appen utan internet
-- ✅ **Native app-upplevelse** - körs i helskärm utan webbläsare
-- ✅ **Automatiska uppdateringar** - alltid senaste versionen
-- ✅ **Litet lagringsbehov** - endast ~50 KB istället för flera MB
-- ✅ **Hemskärmsikon** - snabb åtkomst som en riktig app
+- 📱 **PWA** - Installerbar på alla enheter, fungerar offline
+- 🌐 **3 språk** - Svenska, Tyska, Engelska
+- 🔍 **Sök & Filter** - Efter landskap, svårighetsgrad, typ
+- 📥 **Import/Export** - JSON-backup med dubblettdetektering
+- 🔗 **Klickbara länkar** - URLs och filsökvägar länkas automatiskt
+- 💾 **IndexedDB** - Säker lokal datalagring
 
-### 🌐 **Flerspråkighet**
-- **Svenska** - Standardspråk
-- **Deutsch** - Komplett tysk översättning
-- **English** - Komplett engelsk översättning
-- Språkval uppe till höger i headern
-- Språkval sparas automatiskt
+## 🚀 Installation
 
-### 📊 **Datahantering**
-- ✅ Lägg till, redigera & ta bort låtar
-- ✅ 15 datafält för omfattande dokumentation
-- ✅ Automatisk sparning i localStorage
-- ✅ Data förblir permanent i webbläsaren
-- ✅ Pålitligt ID-system förhindrar oavsiktlig radering av flera poster
+### iPhone/iPad (Safari):
+1. Öppna appen i Safari
+2. Tryck på Dela-symbolen (□↑)
+3. Välj "Lägg till på hemskärmen"
 
-### 🔍 **Sök- och filterfunktioner**
-- Fulltextsökning över alla fält
-- Filtrera efter region (Landskap)
-- Filtrera efter svårighetsgrad
-- Filtrera efter typ (Traditionell/Ny/Modern)
-
-### 📥 **Import & Export**
-- Exportera ditt repertoar som JSON-fil
-- Importera JSON-filer (backup-funktion)
-- **Automatisk dubblettdetektering**: Vid import hoppas låtar som redan finns (alla fält identiska) automatiskt över
-- Säkerhetskopiera dina data regelbundet!
-
-### 📱 **Responsiv design**
-- Fungerar på Desktop, Tablet och Smartphone
-- Modern design med gradient-bakgrund
-- Tydlig tabellvy
-
-## 🚀 Installation & Användning
-
-### 🌟 Installera som PWA (REKOMMENDERAT för iOS/iPad)
-
-Appen kan installeras som en Progressive Web App och körs då som en native app!
-
-#### iPhone/iPad (Safari):
-1. **Öppna app-URL:en** i Safari (t.ex. https://StarOnDavid.github.io/spelbok/)
-2. Tryck på **Dela-symbolen** (□↑)
-3. Välj **"Lägg till på hemskärmen"**
-4. Tryck på **"Lägg till"**
-5. **Klart!** Appen finns nu på din hemskärm som "SpelBok"
-
-#### Android (Chrome):
-1. **Öppna Chrome** och öppna appen
-2. Tryck på **"Installera app"** i bannern
-3. Eller: Meny (⋮) → **"Installera app"**
-4. **Klart!** Appen körs som native app
-
-#### Desktop (Chrome/Edge):
+### Android/Desktop:
 1. Öppna appen i webbläsaren
-2. Klicka på **⊕-ikonen** i adressfältet
-3. Klicka på **"Installera"**
-
-**✨ Fördelar med PWA-installation:**
-- 📱 Körs i helskärm (ingen webbläsare)
-- 🚀 Fungerar offline
-- ⚡ Snabbare start
-- 🏠 Egen ikon på hemskärmen
-- 🔄 Automatiska uppdateringar
-
----
-
-### 📱 PWA vs. normal användning
-
-| Funktion | PWA (installerad) | Normal (webbläsare) |
-|----------|-------------------|---------------------|
-| **Offline** | ✅ Ja | ❌ Nej |
-| **Hemskärmsikon** | ✅ Ja | ❌ Nej |
-| **Helskärm** | ✅ Ja | ❌ Nej |
-| **Snabbare start** | ✅ Ja | 🟡 Långsammare |
-| **Uppdateringar** | ✅ Automatiskt | 🟡 Manuellt |
-
-**Rekommendation:** För bästa upplevelse på mobila enheter, använd PWA-installation!
-
-### Systemkrav
-- Modern webbläsare (Chrome, Firefox, Safari, Edge)
-- JavaScript måste vara aktiverat
-- Ingen internetanslutning krävs
+2. Klicka på "Installera app"
 
 ## 📋 Datafält
 
-Appen registrerar följande information för varje låt:
-
-1. **Titel** - Låtens namn (t.ex. Bingsjöpolska efter Hjort Anders)
-2. **Låttyp** - Typ av låt (t.ex. Polska, Vals, Slängpolska)
-3. **Efter/Av** - Kompositör eller källa
-4. **Ort** - Stad eller by
-5. **Landskap** - Region (t.ex. Dalarna, Skåne)
-6. **Land** - Land (t.ex. Sverige, Norge)
-7. **Tonart** - Låtens tonart
-8. **Svårighetsgrad** - Svårighetsgrad (Lätt/Medel/Svår/Mycket svår)
-9. **Utmaningar** - Utmaningar och övningsfokus
-10. **Av vem lärde jag mig låten?** - Vem du lärde dig låten av
-11. **Var hittar jag inspelning?** - Var inspelningen finns
-12. **Not?** - Tillgång till noter
-13. **Instrument kommentar** - Kommentarer om instrument
-14. **Trad eller ny** - Traditionell, Ny eller Modern tolkning
-15. **Andra kommentarer** - Övriga anteckningar
+Registrera omfattande information om varje låt:
+- Titel, Låttyp, Kompositör, Ort, Landskap, Land
+- Tonart, Svårighetsgrad, Utmaningar
+- Källa, Inspelningar, Noter, Instrument
+- Typ (Traditionell/Ny/Modern), Kommentarer
 
 ## 💾 Datasäkerhet
 
-### Var sparas datan?
-Datan sparas i din webbläsares **localStorage**:
-- ✅ Automatisk sparning vid varje ändring
-- ✅ Datan finns kvar efter omstart av webbläsaren
-- ✅ Inget moln, ingen extern databas
+- Data lagras lokalt i webbläsaren
+- Skapa regelbundna backuper med exportfunktionen
+- Import känner automatiskt igen dubbletter
 
-### ⚠️ Viktiga meddelanden
-- **Rensa inte webbläsarens cache** - då försvinner din data!
-- **Skapa regelbundna backuper** med export-funktionen
-- **Privat surfning** sparar inte data permanent
+## 🛠️ Teknik
 
-### Skapa backup
-1. Klicka på "📥 Exportera JSON"
-2. Spara JSON-filen på en säker plats
-3. Vid behov: Importera filen med "📤 Importera JSON"
+- Vanilla JavaScript, HTML5, CSS3
+- IndexedDB med Dexie.js
+- Service Worker för offline-funktionalitet
+- i18n för flerspråkighet
 
-### Import med dubblettdetektering
-Vid import av JSON-filer kontrollerar appen automatiskt dubbletter:
-- **Dublettkontroll**: Låtar identifieras som dubbletter om ALLA fält (utom ID) är identiska
-- **Automatisk överhoppning**: Dubbletter importeras inte
-- **Statusmeddelande**: Du får ett meddelande om hur många låtar som importerades och hur många som hoppades över
-- **Exempel**: Om du importerar 20 låtar och 5 redan finns, läggs endast 15 nya till
+## 📄 Licens
 
-Detta skyddar mot oavsiktlig dubbel import av samma data!
-
-## 🌐 Byta språk
-
-1. Klicka på **Globe-ikonen** 🌐 uppe till höger
-2. Välj önskat språk:
-   - **Svenska** (Svenska)
-   - **Deutsch** (Tyska)
-   - **English** (Engelska)
-3. Hela användargränssnittet översätts direkt
-4. Ditt språkval sparas automatiskt
-
-## 🎯 Användningstips
-
-### Effektivt arbete
-- Använd **sökning** för snabb åtkomst till specifika låtar
-- Använd **filter** för att sortera ditt repertoar efter kategorier
-- **Statistiken** visar dig snabbt sammansättningen av ditt repertoar
-
-### Best Practices
-- Fyll i så många fält som möjligt - ju mer information, desto bättre
-- Använd "Utmaningar"-fältet för övningsanteckningar
-- Länka inspelningar direkt (YouTube, Spotify, etc.)
-- Skapa en backup av dina data varje vecka
-
-## 🛠️ Tekniska detaljer
-
-### Modern arkitektur (v2.0.0)
-Appen använder en **modulär struktur** med separata filer:
-
-**Struktur:**
-```
-spelbok/
-├── index.html           # Huvud-HTML (Entry Point)
-├── manifest.json        # PWA-konfiguration
-├── sw.js               # Service Worker (Cache v2.0.0)
-├── assets/
-│   ├── css/styles.css  # Stylesheet (7.4 KB)
-│   └── js/app.js       # App-logik (14 KB)
-└── docs/               # Dokumentation
-```
-
-**Service Worker (spelbok-v2.0.0):**
-- Möjliggör offline-funktionalitet
-- Cachar HTML, CSS, JS och manifest.json
-- Automatiska uppdateringar i bakgrunden
-
-**Web App Manifest:**
-- Namn: "SpelBok - Din digitala spelbok"
-- Definierar app-egenskaper (ikoner, färger, start-URL)
-- Möjliggör installation på hemskärmen
-- iOS- och Android-optimerad
-
-**LocalStorage API:**
-- Persistent datalagring i webbläsaren
-- Ingen serveranslutning krävs
-- Datan finns kvar även offline
-
-### ID-system
-Varje låt får ett unikt ID vid skapande i formatet `song_timestamp_randomstring`. Detta ID:
-- Genereras automatiskt
-- Är inte synligt för användaren
-- Garanterar säkra radering- och redigeringsoperationer
-- Förhindrar konflikter vid import/export
-- För befintlig data migreras gamla ID:n automatiskt
-
-### Teknikstack
-- **HTML5, CSS3, ES6 JavaScript** - inga ramverk, ren vanilla JS
-- **localStorage API** - för datalagring
-- **Responsiv design** - fungerar på alla enheter
-- **Progressive Web App** - med Service Worker och Manifest
-- **Flerspråkighet** - Svenska, Tyska, Engelska
-
-### Webbläsarkompatibilitet
-- ✅ Chrome/Chromium (från version 60)
-- ✅ Firefox (från version 50)
-- ✅ Safari (från version 11)
-- ✅ Edge (från version 79)
-- ✅ Opera (från version 47)
-
-## 📄 Licens & Copyright
-
-**© 2025 David Staron**
-
-Denna app är fritt användbar för privat och kommersiellt bruk.
-
----
-
-## 🎵 Ha kul med SpelBok!
+© 2025 David Staron - Fritt användbar


### PR DESCRIPTION
Reduce README files from ~300 to ~60 lines, focus on main features, remove excessive technical details.

Updated: README.md (DE), docs/README.sv.md, docs/README.en.md